### PR TITLE
chore: move a reusable workflow to the required path

### DIFF
--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -1,6 +1,7 @@
-name: Lint
+name: Trunk Check
 
-on: pull_request
+on:
+  workflow_call:
 
 permissions:
   actions: read
@@ -13,5 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+      - uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
## Info
* Renames workflow to be more specific about `trunk` check and move it to the path expected by GHA.
* Includes the `on.workflow_call` trigger to make it reusable.

## References
* https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow