### PR TITLE
chore: gh actions, update and pin to sha

### DIFF
--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: trunk-io/trunk-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
         with:
           setup-deps: ${{ inputs.setup-deps }}


### PR DESCRIPTION
I don't think we got around to these actions -- pin the GitHub Actions to the commit SHA of the versions for security. https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions