### PR TITLE
fix(deps): pin GitHub Actions to commit SHAs (STS-1460)

### DIFF
--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
           setup-deps: ${{ inputs.setup-deps }}


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.
- Upgrades actions to current versions
- Improves supply chain security by preventing mutable tag/branch refs from being silently updated.
- Upgrades trunk as needed to pass CI/CD

## References

- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions